### PR TITLE
RHEL7 and systemd integration

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -273,6 +273,26 @@ INSTALL_OPTS="-o $ndo2db_user -g $ndo2db_group"
 AC_SUBST(INSTALL_OPTS)
 
 
+dnl Does the user want to check for systemd?
+AC_ARG_ENABLE([systemd-sockets],
+	AC_HELP_STRING([--enable-systemd-sockets],[enables systemd socket activation]),
+	[],[enable_systemd_sockets=auto])
+
+dnl Try to compile and link a program that checks for systemd sockets.
+if test x$enable_systemd_sockets != xno; then
+	have_systemd=no
+
+	AC_SEARCH_LIBS([sd_listen_fds],[systemd systemd-daemon],
+		AC_TRY_LINK([#include <systemd/sd-daemon.h>],[sd_listen_fds(0);],[have_systemd=yes]))
+
+	if test x$have_systemd = xyes; then
+		AC_DEFINE([HAVE_SYSTEMD])
+	elif test x$enable_systemd_sockets = xyes; then
+		AC_MSG_ERROR([systemd was requested, but could not be found])
+	fi
+fi
+
+
 dnl Does user want to check for SSL?
 AC_ARG_ENABLE(ssl,AC_HELP_STRING([--enable-ssl],[enables native SSL support]),[
 	if test x$enableval = xyes; then

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -278,6 +278,8 @@ typedef int int32_t;
 #include <mysql/errmsg.h>
 #endif
 
+#undef HAVE_SYSTEMD
+
 #undef HAVE_SSL
 #ifdef HAVE_SSL
 #include <rsa.h>

--- a/src/ndo2db.c
+++ b/src/ndo2db.c
@@ -39,6 +39,10 @@
 #include "../include/dbstatements.h"
 #include "../include/queue.h"
 
+#ifdef HAVE_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 #ifdef HAVE_SSL
 #include "../include/dh.h"
 #endif
@@ -807,6 +811,18 @@ int ndo2db_wait_for_connections(void) {
 	struct sockaddr_in client_address_i;
 	socklen_t client_address_length;
 
+
+#ifdef HAVE_SYSTEMD
+	/* Socket inherited from systemd */
+	if (sd_listen_fds(0) == 1) {
+		ndo2db_sd = SD_LISTEN_FDS_START + 0;
+		if (sd_is_socket_inet(ndo2db_sd, 0, 0, -1, 0))
+			client_address_length = (socklen_t)sizeof(client_address_i);
+		else
+			client_address_length = (socklen_t)sizeof(client_address_u);
+	}
+	else
+#endif
 
 	/* TCP socket */
 	if (ndo2db_socket_type == NDO_SINK_TCPSOCKET) {


### PR DESCRIPTION
I've been working with Nagios on RHEL7 and made some changes to ndo2db for better systemd integration.

For the first patch, systemd tries to read the PID file when the parent process exits, but there is a race condition between the parent process exiting and the PID file being written.  The result is error messages appearing in the log randomly on service starts.  The patch moves writing the lock file contents into the child process and has the parent wait for it to finish before exiting.

The second patch is more of a feature request.  It allows systemd to pass a socket to ndo2db to gain socket activation, automatic SELinux labeling, etc.  A configure option was added for it, but note the commit does not include a regenerated configure (in case my version of autoconf subtly changes something from the ndoutils release version).