### PR TITLE
Added option to specify alternative mysql TCP port on installdb script

### DIFF
--- a/db/installdb
+++ b/db/installdb
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 #
 # SYNTAX:
-my $usage = "installdb -u user -p password -h hostname -d database";
+my $usage = "installdb -u user -p password -h hostname -d database [-P port]";
 #
 # DESCRIPTION:
 #	Runs installation script in this directory
@@ -29,16 +29,17 @@ sub usage {
 }
 
 my $opts = {};
-getopts("u:p:h:d:", $opts) or usage "Bad options";
+getopts("u:p:h:d:P:", $opts) or usage "Bad options";
 
 my $database = $opts->{d} || usage "Must specify a database";
 my $hostname = $opts->{h} || "localhost";
 my $username = $opts->{u} || usage "Must specify a username";
 my $password = $opts->{p};
+my $port = $opts->{P};
 usage "Must specify a password" unless defined $password;	# Could be blank
 
 # Connect to database
-my $dbh = DBI->connect("DBI:mysql:database=$database;host=$hostname",
+my $dbh = DBI->connect("DBI:mysql:$database:$hostname:$port",
 		$username, $password,
 		{ RaiseError => 1 },
 		)


### PR DESCRIPTION
Tested by me:

[jdalrymple@localhost db]$ sudo ./installdb -u ndoutils -p ****** -h 127.0.0.1 -d nagios
*** Database already installed
[jdalrymple@localhost db]$ sudo ./installdb -u ndoutils -p ****** -h 127.0.0.1 -d nagios -P 3307
DBI connect('nagios:127.0.0.1:3307','ndoutils',...) failed: Can't connect to MySQL server on '127.0.0.1' (111) at ./installdb line 42.
[jdalrymple@localhost db]$ sudo ./installdb -u ndoutils -p ****** -h 127.0.0.1 -d nagios -P 3306
*** Database already installed