### PR TITLE
fix for potential collisions when calling ftok (fix for issue #24)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -11,6 +11,7 @@ NDO Utils Changelog
 * Lock/PID file contains 0, instead of actual PID (John Frickson)
 * No root group in FreeBSD and Apple OS X (John Frickson)
 * Incorrect argument in message when MySQL library could not be located (John Frickson)
+* Reduced by quite a margin a probability of potential collisions when calling ftok function (Daniel Svoboda)
 
 
 2.1.1 - 2016-09-06

--- a/src/dbhandlers.c
+++ b/src/dbhandlers.c
@@ -22,6 +22,11 @@
 
 /* include our project's header files */
 #include "../include/config.h"
+/*
+this undef here patches the conflict between pqueue_t from include/nagios-4x/squeue.h
+and pqueue from libssl <openssl/ssl.h>
+*/
+#undef HAVE_SSL
 #include "../include/common.h"
 #include "../include/io.h"
 #include "../include/utils.h"


### PR DESCRIPTION
- implemented use of an empty file for each process id to reduce a potential collision of queue-ids generated by ftok call

- added #undef HAVE_SSL to fix a compilation problem on Ubuntu when --enable-ssl is passed to ./configure