### PR TITLE
Added support for Gentoo init and fixed existing openrc script

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -134,6 +134,10 @@ install-init:
 		echo svccfg import $(INIT_DIR)/$(INIT_FILE); \
 		svccfg import $(INIT_DIR)/$(INIT_FILE); \
 		echo "*** Run 'svcadm enable ndo2db' to start it"; \
+	elif test $(INIT_TYPE) = gentoo; then\
+		$(INSTALL) -m 755 startup/$(SRC_INIT) $(INIT_DIR)/$(INIT_FILE); \
+		echo rc-update add ndo2db default; \
+		rc-update add ndo2db default; \
 	else\
 		echo $(INSTALL) -m 755 startup/$(SRC_INIT) $(INIT_DIR)/$(INIT_FILE); \
 		$(INSTALL) -m 755 startup/$(SRC_INIT) $(INIT_DIR)/$(INIT_FILE); \

--- a/configure
+++ b/configure
@@ -3848,10 +3848,10 @@ fi
 				elif test -f "/sbin/rc"; then
 					if test -f /sbin/runscript; then
 						init_type_wanted=no
-						if `/sbin/start-stop-daemon -V | grep "OpenRC" > /dev/null`; then
-							init_type="openrc"
-						else
+						if `/sbin/start-stop-daemon -V | grep "OpenRC.*Gentoo" > /dev/null`; then
 							init_type="gentoo"
+						else
+							init_type="openrc"
 						fi
 					fi
 				fi
@@ -4738,10 +4738,10 @@ case $init_type in #(
 			bsd_enable=""
 			src_init=newbsd-init
 		fi ;; #(
-  #	[gentoo],
-
 	openrc) :
     src_init=openrc-init ;; #(
+  gentoo) :
+    src_init=gentoo-init ;; #(
   smf*) :
     src_init="solaris-init.xml"
 		src_inetd="solaris-inetd.xml" ;; #(
@@ -6851,7 +6851,7 @@ _ACEOF
 	fi
 fi
 
-ac_config_files="$ac_config_files Makefile src/Makefile config/ndo2db.cfg-sample config/ndomod.cfg-sample config/nagios.cfg config/misccommands.cfg docs/docbook/en-en/Makefile include/io.h include/common.h startup/bsd-init startup/debian-init startup/default-init startup/default-inetd startup/default-service startup/default-socket startup/default-socket-svc startup/default-xinetd startup/mac-init.plist startup/mac-inetd.plist startup/newbsd-init startup/openbsd-init startup/openrc-conf startup/openrc-init startup/solaris-init.xml startup/solaris-inetd.xml startup/tmpfile.conf startup/upstart-init startup/rh-upstart-init"
+ac_config_files="$ac_config_files Makefile src/Makefile config/ndo2db.cfg-sample config/ndomod.cfg-sample config/nagios.cfg config/misccommands.cfg docs/docbook/en-en/Makefile include/io.h include/common.h startup/bsd-init startup/debian-init startup/default-init startup/default-inetd startup/default-service startup/default-socket startup/default-socket-svc startup/default-xinetd startup/mac-init.plist startup/mac-inetd.plist startup/newbsd-init startup/openbsd-init startup/openrc-conf startup/gentoo-init startup/openrc-init startup/solaris-init.xml startup/solaris-inetd.xml startup/tmpfile.conf startup/upstart-init startup/rh-upstart-init"
 
 
 

--- a/startup/gentoo-init.in
+++ b/startup/gentoo-init.in
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 #
 # Copyright (c) 2016 Nagios(R) Core(TM) Development Team
 #
@@ -8,9 +8,11 @@
 
 NDO2DB_BIN="@sbindir@/ndo2db"
 NDO2DB_PID="@piddir@/ndo2db.pid"
+NDO2DB_CFG=@pkgsysconfdir@/ndo2db.cfg
 
-depend() {
-	use logger dns net localmount netmount nfsmount
+depends() {
+	before nagios
+	need mysql
 }
 
 checkconfig() {
@@ -27,13 +29,13 @@ start() {
 	ebegin "Starting ndo2db"
 	# Make sure we have a sane current directory
 	cd /
-	start-stop-daemon --start --exec $NDO2DB_BIN --pidfile $PID_FILE \
-		-- -c $NDO2DB_CFG -f
+	start-stop-daemon --start --exec $NDO2DB_BIN --pidfile $NDO2DB_PID \
+		--background -- -c $NDO2DB_CFG -f
 	eend $?
 }
 
 stop() {
 	ebegin "Stopping ndo2db"
-	start-stop-daemon --stop --exec $NDO2DB_BIN --pidfile $PID_FILE
+	start-stop-daemon --stop --exec $NDO2DB_BIN --pidfile $NDO2DB_PID
 	eend $?
 }


### PR DESCRIPTION
While testing NDOUtils on Gentoo I found some changes were required to make it work. I suspect that Gentoo's OpenRC implementation is slightly different so I created a separate startup script. Also added a missing " in the 'openrc-init.in' script I used for the 'gentoo-init.in' script.