### PR TITLE
Secure executable permissions

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -37,7 +37,6 @@ INSTALL=@INSTALL@
 GREP=@GREP@
 EGREP=@EGREP@
 
-INSTALL_OPTS=@INSTALL_OPTS@
 OPSYS=@opsys@
 DIST=@dist_type@
 
@@ -98,10 +97,10 @@ install:
 	@echo ""
 
 install-config:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(PIPEDIR)
-	$(INSTALL) -m 644 $(INSTALL_OPTS) config/ndo2db.cfg-sample $(DESTDIR)$(CFGDIR)
-	$(INSTALL) -m 644 $(INSTALL_OPTS) config/ndomod.cfg-sample $(DESTDIR)$(CFGDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(CFGDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(PIPEDIR)
+	$(INSTALL) -m 644 config/ndo2db.cfg-sample $(DESTDIR)$(CFGDIR)
+	$(INSTALL) -m 644 config/ndomod.cfg-sample $(DESTDIR)$(CFGDIR)
 	@echo ""
 	@echo "*** Config files installed ***"
 	@echo ""

--- a/configure.ac
+++ b/configure.ac
@@ -317,8 +317,6 @@ AC_ARG_WITH(ndo2db_user,AC_HELP_STRING([--with-ndo2db-user=<user>],[sets user na
 AC_ARG_WITH(ndo2db_group,AC_HELP_STRING([--with-ndo2db-group=<group>],[sets group name to run NDO2DB]),ndo2db_group=$withval,ndo2db_group=nagios)
 AC_SUBST(ndo2db_user)
 AC_SUBST(ndo2db_group)
-INSTALL_OPTS="-o $ndo2db_user -g $ndo2db_group"
-AC_SUBST(INSTALL_OPTS)
 
 
 dnl Does the user want to check for systemd?

--- a/docs/docbook/en-en/Makefile.in
+++ b/docs/docbook/en-en/Makefile.in
@@ -13,7 +13,6 @@ BINDIR=@bindir@
 LIBEXECDIR=@libexecdir@
 DATAROOTDIR=@datarootdir@
 INSTALL=@INSTALL@
-INSTALL_OPTS=@INSTALL_OPTS@
 
 
 all:

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -125,9 +125,9 @@ distclean: clean
 devclean: distclean
 
 install: install-4x
-	$(INSTALL) -m 774 file2sock $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 774 log2ndo $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 774 sockdebug $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 file2sock $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 log2ndo $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 sockdebug $(DESTDIR)$(BINDIR)
 	@echo ""
 	@echo "  Hint: NDOUtils Installation against Nagios v4.x"
 	@echo "  completed."

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -26,7 +26,6 @@ exec_prefix=@exec_prefix@
 PIPEDIR=@localstatedir@
 BINDIR=@bindir@
 INSTALL=@INSTALL@
-INSTALL_OPTS=@INSTALL_OPTS@
 
 CC=@CC@
 
@@ -126,9 +125,9 @@ distclean: clean
 devclean: distclean
 
 install: install-4x
-	$(INSTALL) -m 774 $(INSTALL_OPTS) file2sock $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 774 $(INSTALL_OPTS) log2ndo $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 774 $(INSTALL_OPTS) sockdebug $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 774 file2sock $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 774 log2ndo $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 774 sockdebug $(DESTDIR)$(BINDIR)
 	@echo ""
 	@echo "  Hint: NDOUtils Installation against Nagios v4.x"
 	@echo "  completed."
@@ -147,20 +146,20 @@ install: install-4x
 	@echo ""
 
 install-2x:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(PIPEDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 755 $(INSTALL_OPTS) ndo2db-2x $(DESTDIR)$(BINDIR)/ndo2db
-	$(INSTALL) -m 755 $(INSTALL_OPTS) ndomod-2x.o $(DESTDIR)$(BINDIR)/ndomod.o
+	$(INSTALL) -m 775 -d $(DESTDIR)$(PIPEDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 ndo2db-2x $(DESTDIR)$(BINDIR)/ndo2db
+	$(INSTALL) -m 755 ndomod-2x.o $(DESTDIR)$(BINDIR)/ndomod.o
 
 install-3x:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(PIPEDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 755 $(INSTALL_OPTS) ndo2db-3x $(DESTDIR)$(BINDIR)/ndo2db
-	$(INSTALL) -m 755 $(INSTALL_OPTS) ndomod-3x.o $(DESTDIR)$(BINDIR)/ndomod.o
+	$(INSTALL) -m 775 -d $(DESTDIR)$(PIPEDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 ndo2db-3x $(DESTDIR)$(BINDIR)/ndo2db
+	$(INSTALL) -m 755 ndomod-3x.o $(DESTDIR)$(BINDIR)/ndomod.o
 
 install-4x:
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(PIPEDIR)
-	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 755 $(INSTALL_OPTS) ndo2db-4x $(DESTDIR)$(BINDIR)/ndo2db
-	$(INSTALL) -m 755 $(INSTALL_OPTS) ndomod-4x.o $(DESTDIR)$(BINDIR)/ndomod.o
+	$(INSTALL) -m 775 -d $(DESTDIR)$(PIPEDIR)
+	$(INSTALL) -m 775 -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 ndo2db-4x $(DESTDIR)$(BINDIR)/ndo2db
+	$(INSTALL) -m 755 ndomod-4x.o $(DESTDIR)$(BINDIR)/ndomod.o
 


### PR DESCRIPTION
Installing executables as `nagios:nagios` (the default) is a security issue on a typical system where those executables will wind up in everyone's `PATH`. In these two commits I simply delete the special handling, letting all executables be installed mode 755 with the owner unchanged. (This would result in `root:root` ownership for a "normal" `/usr/bin` install.)