### PR TITLE
include/queue.h: ensure prototypes match implementations

### DIFF
--- a/include/queue.h
+++ b/include/queue.h
@@ -37,7 +37,7 @@ struct queue_msg
 void del_queue();
 
 /* initialize new queue or open existing */
-int get_queue_id();
+int get_queue_id(int);
 
 /* insert into queue */
 void push_into_queue(char*);


### PR DESCRIPTION
In the latest C23 standard, the prototype

```C
int get_queue_id();
```

indicates that get_queue_id takes no arguments. This of course disagrees with its implementation, which takes one argument. C23 will be the default mode in GCC-15, where this leads to a build failure:

```
queue.c:57:5: error: conflicting types for 'get_queue_id'; have 'int(int)'
 57 | int get_queue_id(int id) {
    |     ^~~~~~~~~~~~
In file included from queue.c:30:
../include/queue.h:40:5: note: previous declaration of 'get_queue_id' with
type 'int(void)'
 40 | int get_queue_id();
    |     ^~~~~~~~~~~~
```

To fix it, we update the prototype for `get_queue_id()`.
