### PR TITLE
Simplify the OpenRC init script and conf file

### DIFF
--- a/startup/openrc-conf.in
+++ b/startup/openrc-conf.in
@@ -1,4 +1,2 @@
-# /etc/conf.d/ndo2db : config file for /etc/init.d/ndo2db
-
-# Configuration file - default is @sysconfdir@/ndo2db.cfg
-NDO2DB_CFG="@pkgsysconfdir@/ndo2db.cfg"
+# The configuration file to use for ndo2db.
+NDO2DB_CFG="@sysconfdir@/ndo2db.cfg"

--- a/startup/openrc-init.in
+++ b/startup/openrc-init.in
@@ -1,39 +1,15 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 #
-# Copyright (c) 2016 Nagios(R) Core(TM) Development Team
+# Copyright (c) 2017 Nagios(R) Core(TM) Development Team
 #
-# Start/stop the Nagios Data Out Daemon.
-#
-# Goes in /etc/init.d - Config is in /etc/conf.d/ndo2db
 
-NDO2DB_BIN="@sbindir@/ndo2db"
-NDO2DB_PID="@piddir@/ndo2db.pid"
+command="@sbindir@/ndo2db"
+command_args="-c ${NDO2DB_CFG}"
+description="Nagios Data Out daemon"
+pidfile="@piddir@/ndo2db.pid"
 
 depend() {
-	use logger dns net localmount netmount nfsmount
-}
-
-checkconfig() {
-	# Make sure the config file exists
-	if [ ! -f $NDO2DB_CFG ]; then
-		eerror "You need to setup $NDO2DB_CFG.
-		return 1
-	fi
-	return 0
-}
-
-start() {
-	checkconfig || return 1
-	ebegin "Starting ndo2db"
-	# Make sure we have a sane current directory
-	cd /
-	start-stop-daemon --start --exec $NDO2DB_BIN --pidfile $PID_FILE \
-		-- -c $NDO2DB_CFG -f
-	eend $?
-}
-
-stop() {
-	ebegin "Stopping ndo2db"
-	start-stop-daemon --stop --exec $NDO2DB_BIN --pidfile $PID_FILE
-	eend $?
+    # The Nagios core daemon creates the socket that ndo2db tries to
+    # connect to upon starting.
+    need mysql nagios
 }


### PR DESCRIPTION
The commit message does some explaining. We've had this patch in Gentoo for a long time. While I hate to use this argument, I'm the Gentoo maintainer for ndoutils, and I wrote the OpenRC service script guide, so unless you know someone else who uses OpenRC, you should probably just trust me :)