### PR TITLE
config/ndo2db.cfg-sample.in: use @piddir@ for the pid file.

### DIFF
--- a/config/ndo2db.cfg-sample.in
+++ b/config/ndo2db.cfg-sample.in
@@ -10,7 +10,7 @@
 # This is the lockfile that NDO2DB will use to store its PID number
 # in when it is running in daemon mode.
 
-lock_file=@localstatedir@/ndo2db.pid
+lock_file=@piddir@/ndo2db.pid
 
 
 


### PR DESCRIPTION
(Related to https://github.com/NagiosEnterprises/ndoutils/pull/71, but useful independently)

The "lock_file" setting in `ndo2db.cfg` specifies where the daemon's pid file should be stored. In the past, it was stored in `@localstatedir@`, but `@piddir@` is more appropriate. As evidence, all of the init scripts in the "startup" directory reference `@piddir@` and not `@localstatedir@` for the location of the pid file. This commit updates the sample config to agree with the init scripts.