### PR TITLE
src/queue.c: fix format-security warnings

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -50,7 +50,7 @@ void del_queue() {
 	struct msqid_ds buf;
 
 	if (msgctl(queue_id,IPC_RMID,&buf) < 0) {
-		syslog(LOG_ERR,"Error: queue remove error.\n");
+		syslog(LOG_ERR, "%s", "Error: queue remove error.\n");
 	}
 }
 
@@ -58,7 +58,7 @@ int get_queue_id(int id) {
 	key_t key = ftok(NDO_QUEUE_PATH, NDO_QUEUE_ID+id);
 
 	if ((queue_id = msgget(key, IPC_CREAT | 0600)) < 0) {
-		syslog(LOG_ERR,"Error: queue init error.\n");
+		syslog(LOG_ERR, "%s", "Error: queue init error.\n");
 	}
 }
 
@@ -99,7 +99,7 @@ void log_retry( void) {
 		if(msgctl(queue_id, IPC_STAT, &queue_stats)) {
 			sprintf(curstats, "Unable to determine current message queue usage: error reading IPC_STAT: %d", errno);
 			sprintf(logmsg, logfmt, curstats);
-			syslog(LOG_ERR, logmsg);
+			syslog(LOG_ERR, "%s", logmsg);
 			}
 		else {
 #if defined( __linux__)
@@ -108,24 +108,24 @@ void log_retry( void) {
 			if( msgmni < 0) {
 				sprintf(curstats, "Unable to determine current message queue usage: error reading IPC_INFO: %d", errno);
 				sprintf(logmsg, logfmt, curstats);
-				syslog(LOG_ERR, logmsg);
+				syslog(LOG_ERR, "%s", logmsg);
 				}
 			else {
 				sprintf(curstats, statsfmt, queue_stats.msg_qnum,
 						(unsigned long)msgmni, queue_stats.__msg_cbytes,
 						queue_stats.msg_qbytes);
 				sprintf(logmsg, logfmt, curstats);
-				syslog(LOG_ERR, logmsg);
+				syslog(LOG_ERR, "%s", logmsg);
 				}
 #else
 			sprintf(logmsg, logfmt, "");
-			syslog(LOG_ERR, logmsg);
+			syslog(LOG_ERR, "%s", logmsg);
 #endif
 			}
 		last_retry_log_time = now;
 		}
 	else {
-		syslog(LOG_ERR,"Warning: queue send error, retrying...\n");
+		syslog(LOG_ERR, "%s", "Warning: queue send error, retrying...\n");
 		}
 }
 
@@ -155,14 +155,14 @@ void push_into_queue (char* buf) {
 					#endif
 				}
 				if (retrynum < MAX_RETRIES) {
-					syslog(LOG_ERR,"Message sent to queue.\n");
+					syslog(LOG_ERR, "%s", "Message sent to queue.\n");
 					}
 				else {
-					syslog(LOG_ERR,"Error: max retries exceeded sending message to queue. Kernel queue parameters may need to be tuned. See README.\n");
+					syslog(LOG_ERR, "%s", "Error: max retries exceeded sending message to queue. Kernel queue parameters may need to be tuned. See README.\n");
 				}
 			}
 		else {
-			syslog(LOG_ERR,"Error: queue send error.\n");
+			syslog(LOG_ERR, "%s", "Error: queue send error.\n");
 			}
 		}
 
@@ -175,7 +175,7 @@ char* pop_from_queue() {
 	zero_string(msg.text, NDO_MAX_MSG_SIZE);
 
 	if (msgrcv(queue_id, &msg, queue_buff_size, NDO_MSG_TYPE, MSG_NOERROR) < 0) {
-		syslog(LOG_ERR,"Error: queue recv error.\n");
+		syslog(LOG_ERR, "%s", "Error: queue recv error.\n");
 	}
 
 	int size = strlen(msg.text);


### PR DESCRIPTION
The `syslog()` function takes as its second argument a format string (a la printf), but if the third parameter is a string, then the format string can be omitted. This has led to security vulnerabilities in the past, and compilers can now warn about it. In particular, GCC has the `-Wformat-security` option, which can be made an error with `-Werror=format-security`.

A few such two-argument calls were present in `src/queue.c`, where constant strings were being logged to syslog. This commit adds the second format string parameter (simply "%s" in this case) to avoid the compiler warnings.

More information about format-security can be found in [Fedora's FAQ](https://fedoraproject.org/wiki/Format-Security-FAQ)